### PR TITLE
Fix/parse payload array body error

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -26,7 +26,7 @@ type WebhookRequest struct {
 	*AppRequest
 
 	Data struct {
-		Payload map[string]interface{} `json:"payload"`
+		Payload []map[string]interface{} `json:"payload"`
 		Event   string                 `json:"event"`
 	} `json:"data"`
 }


### PR DESCRIPTION
According to your [docs](https://developer.shopware.com/docs/resources/references/app-reference/webhook-events-reference) the `payload` is an array and not a map itself. 

When you change a product, the webhook parsing will fail with a bad request error.

```go
type WebhookRequest struct {
	*AppRequest

	Data struct {
		Payload map[string]interface{} `json:"payload"` //this must be an array
		Event   string                   `json:"event"`
	} `json:"data"`
}
```

This PR should solve this issue and allow the webhooks to work again.